### PR TITLE
Changeset

### DIFF
--- a/.changeset/angry-singers-beam.md
+++ b/.changeset/angry-singers-beam.md
@@ -1,0 +1,8 @@
+---
+'caseparser': major
+---
+
+* This version enable bundlers to eliminate unused code (treeshake).
+* Bump @babel/traverse from 7.21.4 to 7.23.2
+* Bump postcss from 8.4.21 to 8.4.31
+* Bump vite from 4.2.1 to 4.4.8


### PR DESCRIPTION
* This version enable bundlers to eliminate unused code (treeshake).
* Bump @babel/traverse from 7.21.4 to 7.23.2
* Bump postcss from 8.4.21 to 8.4.31
* Bump vite from 4.2.1 to 4.4.8